### PR TITLE
Fix title of menu item to prevent confusion about the name of the plugin

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -37,7 +37,7 @@
   "browser_action": {
     "default_popup": "src/popup.html",
     "default_icon": "src/icon/48.png",
-    "default_title": "FediFollow settings"
+    "default_title": "FediAct settings"
   },
   "icons": {
     "48": "src/icon/48.png"


### PR DESCRIPTION
Currently the menu title is wrong, this lead me to confuse it with the old name and embarrass myself. It should instead say FediAct.